### PR TITLE
GDI-6 Modificación en los campos de ingreso de encargados

### DIFF
--- a/ProyectoDAS/src/app/componentes/personal/encargados/encargados.component.ts
+++ b/ProyectoDAS/src/app/componentes/personal/encargados/encargados.component.ts
@@ -188,7 +188,7 @@ export class EncargadosComponent {
   handleInput(event: any) {
     const inputValue = event.target.value;
     if (!this.soloLetrasRegex.test(inputValue)) {
-      event.target.value = inputValue.replace(/[^a-zA-Z]/g, '');
+      event.target.value = inputValue.replace(/[^a-zA-Z\s]/g, '');
     }
   }
 


### PR DESCRIPTION
Se permitió el ingreso de espacios en blanco en los campos de nombre y apellido al ingresar un nuevo encargado