### PR TITLE
Gdi 29 cambio de tipos de datos admitidos en bloques y facultades

### DIFF
--- a/ProyectoDAS/src/app/componentes/infraestructura/bloques/bloques.component.html
+++ b/ProyectoDAS/src/app/componentes/infraestructura/bloques/bloques.component.html
@@ -20,7 +20,7 @@
                             </p-inputIcon>
                             <input pInputText type="text"
                                 (input)="dt.filterGlobal($any($event.target).value, 'contains')"
-                                placeholder="Buscar Bloque" />
+                                placeholder="Buscar Bloque" (input)="handleInput($event)"/>
                         </p-iconField>
                     </div>
                 </ng-template>
@@ -29,7 +29,7 @@
                         <th>
                             <span class="flex mb-2">NOMBRE</span>
                             <p-columnFilter class="mt-5" [matchModeOptions]="matchModeOptions" type="text"
-                                field="nombre" placeholder="Buscar por nombre" ariaLabel="Filter Nombre" />
+                                field="nombre" placeholder="Buscar por nombre" ariaLabel="Filter Nombre" (input)="handleInput($event)"/>
                         </th>
                         <th>
                             <span class="flex mb-2">FACULTAD A LA QUE PERTENECE</span>

--- a/ProyectoDAS/src/app/componentes/infraestructura/bloques/bloques.component.html
+++ b/ProyectoDAS/src/app/componentes/infraestructura/bloques/bloques.component.html
@@ -87,7 +87,7 @@
                 </div>  
                 <div class="flex align-items-left gap-3 mb-3 flex-column" style="max-width: 50%;">
                     <label for="nombre" class="font-semibold w-6rem">Nombre</label>
-                    <input pInputText id="nombre" autocomplete="off" [(ngModel)]="nombre" maxlength="20"/>
+                    <input pInputText id="nombre" autocomplete="off" [(ngModel)]="nombre" maxlength="20" (input)="handleInput($event)/>
                 </div>
             </div>
         </div>

--- a/ProyectoDAS/src/app/componentes/infraestructura/bloques/bloques.component.html
+++ b/ProyectoDAS/src/app/componentes/infraestructura/bloques/bloques.component.html
@@ -87,7 +87,7 @@
                 </div>  
                 <div class="flex align-items-left gap-3 mb-3 flex-column" style="max-width: 50%;">
                     <label for="nombre" class="font-semibold w-6rem">Nombre</label>
-                    <input pInputText id="nombre" autocomplete="off" [(ngModel)]="nombre" maxlength="20" (input)="handleInput($event)/>
+                    <input pInputText id="nombre" autocomplete="off" [(ngModel)]="nombre" maxlength="20" (input)="handleInput($event)" />
                 </div>
             </div>
         </div>

--- a/ProyectoDAS/src/app/componentes/infraestructura/facultades/facultades.component.html
+++ b/ProyectoDAS/src/app/componentes/infraestructura/facultades/facultades.component.html
@@ -20,7 +20,7 @@
                             </p-inputIcon>
                             <input pInputText type="text"
                                 (input)="dt.filterGlobal($any($event.target).value, 'contains')"
-                                placeholder="Buscar Facultad" />
+                                placeholder="Buscar Facultad" (input)="handleInput($event)"/>
                         </p-iconField>
                     </div>
                 </ng-template>
@@ -29,12 +29,12 @@
                         <th>
                             <span class="flex mb-2">NOMBRE</span>
                             <p-columnFilter class="mt-5" [matchModeOptions]="matchModeOptions" type="text"
-                                field="nombre" placeholder="Buscar por nombre" ariaLabel="Filter Nombre" />
+                                field="nombre" placeholder="Buscar por nombre" ariaLabel="Filter Nombre" (input)="handleInput($event)" />
                         </th>
                         <th>
                             <span class="flex mb-2">SIGLAS</span>
                             <p-columnFilter class="mt-5" [matchModeOptions]="matchModeOptions" type="text"
-                                field="siglas" placeholder="Buscar por siglas" ariaLabel="Filter Siglas" />
+                                field="siglas" placeholder="Buscar por siglas" ariaLabel="Filter Siglas" (input)="handleInput($event)"/>
                         </th>
                         <th *ngIf="rolUsuario === 1"></th>
                     </tr>


### PR DESCRIPTION
Se ha implementado la restricción en los campos de nombre de bloques y facultades, así como en los campos de búsqueda asociados, para que solo admitan letras y no números. Esta medida asegura que los nombres ingresados sean exclusivamente alfabéticos, mejorando la consistencia y la integridad de los datos en el sistema de gestión de inventarios. Con esta corrección, se evita la entrada de caracteres numéricos, garantizando una mayor precisión y fiabilidad en la información registrada y buscada en el sistema.